### PR TITLE
[improve-has-focus] Improve the has focus getting rid of third party dependencies

### DIFF
--- a/mixins/_has-focus.scss
+++ b/mixins/_has-focus.scss
@@ -1,3 +1,4 @@
+// stylelint-disable scss/media-feature-value-dollar-variable
 /// Styles touch/hover states according to browser capabilities
 /// @param {boolean} $toggle - State toggle; Available values: `true`, `false` or `default` (for both)
 ///
@@ -5,16 +6,16 @@
     $is-default: ($toggle == default);
 
     @if ($toggle or $is-default) {
-        @include dp-has-support((touchevents: false)) {
-            &:hover, &:focus, &[data-focus] {
+        // the ms-directives are needed to target IE
+        // TODO: remember to remove them when IE will be no long supported
+        @media screen and (hover: hover), (-ms-high-contrast: active), (-ms-high-contrast: none) {
+            &:hover, &:focus {
                 @content;
             }
         }
 
-        @include dp-has-support((touchevents: true)) {
-            &:active, &[data-focus] {
-                @content;
-            }
+        &:active {
+            @content;
         }
     }
 

--- a/mixins/_has-focus.scss
+++ b/mixins/_has-focus.scss
@@ -1,4 +1,5 @@
 // stylelint-disable scss/media-feature-value-dollar-variable
+
 /// Styles touch/hover states according to browser capabilities
 /// @param {boolean} $toggle - State toggle; Available values: `true`, `false` or `default` (for both)
 ///
@@ -6,21 +7,24 @@
     $is-default: ($toggle == default);
 
     @if ($toggle or $is-default) {
-        // the ms-directives are needed to target IE
-        // TODO: remember to remove them when IE will be no long supported
+        // The `-ms-high-contrast` directives are needed to target Internet Explorer 10 and 11
+        // @link https://stackoverflow.com/q/28417056/1602864
+        // TODO: Remove the `-ms-high-contrast` directives when IE will no longer be supported
         @media screen and (hover: hover), (-ms-high-contrast: active), (-ms-high-contrast: none) {
             &:hover, &:focus {
                 @content;
             }
         }
 
-        &:active {
-            @content;
+        @media screen {
+            &:active {
+                @content;
+            }
         }
     }
 
     @if ((not $toggle) or $is-default) {
-        @include dp-at-root(html) {
+        @media all {
             & {
                 @content;
             }


### PR DESCRIPTION
This PR will get rid of the custom `has-support` mixin improving the `has-focus` helper using only pure CSS without relying on modernizr.
This change is a breaking change.

Side note:
According to my tests the `pointer: fine` seems to be supported also by Internet Explorer 11
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer
https://whatwebcando.today/pointer-adaptation.html